### PR TITLE
テストコードのDexieモジュールインポート問題とテスト失敗の修正 (#18)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,17 +3,15 @@ module.exports = {
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\.tsx?$': ['ts-jest', { isolatedModules: true }]
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(dexie|fake-indexeddb)/)'
+  ],
   moduleNameMapper: {
-    '^.+\\.css$': '<rootDir>/src/tests/mocks/styleMock.js'
+    '^.+\.css$': '<rootDir>/src/tests/mocks/styleMock.js'
   },
   setupFiles: ['<rootDir>/src/tests/setup.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  testRegex: '(/__tests__/.*|(\\\\.|/)(test|spec))\\\\.(jsx?|tsx?)$',
-  globals: {
-    'ts-jest': {
-      isolatedModules: true
-    }
-  }
+  testRegex: '(/__tests__/.*|(\.|/)(test|spec))\.(jsx?|tsx?)$',
 };


### PR DESCRIPTION
## 概要
Issue #18 に対応し、テストコードのDexieモジュールインポート問題と、テスト失敗の問題を修正しました。

## 修正内容

### 1. Jest設定の修正
- `transformIgnorePatterns` を追加し、Dexieモジュールを適切に処理できるようにしました
- ts-jestの設定方式を現在推奨される形式に更新しました

```javascript
transform: {
  '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }]
},
transformIgnorePatterns: [
  '/node_modules/(?!(dexie|fake-indexeddb)/)'
],
```

### 2. ReadingListServiceのテスト修正
- モック関数の戻り値を適切に設定し、テストが正常に実行できるようにしました
- `initialize` テストにより具体的なモック設定を追加しました
- メソッド実行前に適切なモック応答を設定し、モック関数が確実に呼び出されるようにしました

## 動作確認
- テスト実行時に発生していたDexieモジュールのインポートエラーが解消されました
- `ReadingListService` テストの失敗していたケースが修正され、全テストが正常に実行されるようになりました

## 関連情報
Close #18